### PR TITLE
Add EC2 Check Reboot Role

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,13 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_iam_policy.datadog_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.ec2_check_reboot_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.sla_reporter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.admin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.ci_cd_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.cloudwatch_share_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.datadog_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.ec2_check_reboot_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.nagios_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.poweruser](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.readonly](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -88,16 +90,20 @@ No modules.
 | [aws_iam_role_policy_attachment.admin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.cloudwatch_share_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.datadog_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.ec2_check_reboot_attach](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.nagios_cloudwatch_budget_read](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.nagios_cloudwatch_read](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.poweruser](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.readonly](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.sla_reporter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachments_exclusive.ci_cd_iam_role_attach](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachments_exclusive) | resource |
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.assume_role_with_mfa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ci_cd_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cloudwatch_share_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.datadog_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.ec2_check_reboot_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.ec2_check_reboot_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.nagios_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.sla_reporter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
@@ -136,6 +142,7 @@ No modules.
 | <a name="input_readonly_role_requires_mfa"></a> [readonly\_role\_requires\_mfa](#input\_readonly\_role\_requires\_mfa) | Whether readonly role requires MFA | `bool` | `true` | no |
 | <a name="input_trusted_role_arns"></a> [trusted\_role\_arns](#input\_trusted\_role\_arns) | ARNs of AWS entities who can assume these roles | `list(string)` | `[]` | no |
 | <a name="input_trusted_roles_ci_cd"></a> [trusted\_roles\_ci\_cd](#input\_trusted\_roles\_ci\_cd) | ARNs of AWS entities who can assume these roles for CI/CD | `list(string)` | `[]` | no |
+| <a name="input_trusted_user_ec2_check_reboot"></a> [trusted\_user\_ec2\_check\_reboot](#input\_trusted\_user\_ec2\_check\_reboot) | Provide a user that is allowed to check and reboot EC2 instances with SSM. | `string` | `""` | no |
 
 ## Outputs
 

--- a/ci_cd_role.tf
+++ b/ci_cd_role.tf
@@ -1,8 +1,8 @@
 resource "aws_iam_role" "ci_cd_iam_role" {
   count = var.create_ci_cd_role ? 1 : 0
 
-  name                = "ci_cd_access_role"
-  assume_role_policy  = data.aws_iam_policy_document.ci_cd_policy_document[0].json
+  name               = "ci_cd_access_role"
+  assume_role_policy = data.aws_iam_policy_document.ci_cd_policy_document[0].json
 
   dynamic "inline_policy" {
     for_each = var.ci_cd_role_inline_policies

--- a/githubagent_role.tf
+++ b/githubagent_role.tf
@@ -1,0 +1,74 @@
+data "aws_iam_policy_document" "ec2_check_reboot_assume_role_policy" {
+  count = var.trusted_user_ec2_check_reboot != "" ? 1 : 0
+
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [var.trusted_user_ec2_check_reboot]
+    }
+  }
+}
+
+resource "aws_iam_role" "ec2_check_reboot_role" {
+  count = var.trusted_user_ec2_check_reboot != "" ? 1 : 0
+
+  name               = "EC2CheckRebootRole"
+  assume_role_policy = data.aws_iam_policy_document.ec2_check_reboot_assume_role_policy[0].json
+}
+
+data "aws_iam_policy_document" "ec2_check_reboot_policy" {
+  count = var.trusted_user_ec2_check_reboot != "" ? 1 : 0
+
+  statement {
+    sid = "ListEC2Instances"
+
+    actions = [
+      "ec2:DescribeInstances",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+  statement {
+    sid = "SendSSMCommands"
+
+    actions = [
+      "ssm:SendCommand",
+      "ssm:ListCommands",
+      "ssm:ListCommandInvocations",
+      "ssm:DescribeInstanceInformation",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+  statement {
+    sid = "RebootEC2Instances"
+
+    actions = [
+      "ec2:RebootInstances",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "ec2_check_reboot_policy" {
+  count = var.trusted_user_ec2_check_reboot != "" ? 1 : 0
+
+  name   = "EC2CheckRebootPolicy"
+  policy = data.aws_iam_policy_document.ec2_check_reboot_policy[0].json
+}
+
+resource "aws_iam_role_policy_attachment" "ec2_check_reboot_attach" {
+  count = var.trusted_user_ec2_check_reboot != "" ? 1 : 0
+
+  role       = aws_iam_role.ec2_check_reboot_role[0].name
+  policy_arn = aws_iam_policy.ec2_check_reboot_policy[0].arn
+}

--- a/githubagent_role.tf
+++ b/githubagent_role.tf
@@ -6,7 +6,7 @@ data "aws_iam_policy_document" "ec2_check_reboot_assume_role_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = [var.trusted_user_ec2_check_reboot]
+      identifiers = ["arn:aws:iam::152144172650:user/${var.trusted_user_ec2_check_reboot}"]
     }
   }
 }

--- a/githubagent_role.tf
+++ b/githubagent_role.tf
@@ -40,6 +40,7 @@ data "aws_iam_policy_document" "ec2_check_reboot_policy" {
       "ssm:ListCommands",
       "ssm:ListCommandInvocations",
       "ssm:DescribeInstanceInformation",
+      "ssm:StartSession"
     ]
 
     resources = [

--- a/variables.tf
+++ b/variables.tf
@@ -198,3 +198,11 @@ variable "ci_cd_role_managed_policies" {
   description = "Managed policies list."
   type        = list(string)
 }
+
+# GitHub Agent
+
+variable "trusted_user_ec2_check_reboot" {
+  default = ""
+  type = string
+  description = "Provide a user that is allowed to check and reboot EC3 instances with SSM."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -202,7 +202,7 @@ variable "ci_cd_role_managed_policies" {
 # GitHub Agent
 
 variable "trusted_user_ec2_check_reboot" {
-  default = ""
-  type = string
+  default     = ""
+  type        = string
   description = "Provide a user that is allowed to check and reboot EC2 instances with SSM."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -204,5 +204,5 @@ variable "ci_cd_role_managed_policies" {
 variable "trusted_user_ec2_check_reboot" {
   default = ""
   type = string
-  description = "Provide a user that is allowed to check and reboot EC3 instances with SSM."
+  description = "Provide a user that is allowed to check and reboot EC2 instances with SSM."
 }


### PR DESCRIPTION
When enabled, this role allows the selected user to execute EC2 and SSM commands.